### PR TITLE
(LIB) evtx 0.11.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -815,9 +815,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.16.0"
+version = "3.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79296716171880943b8470b5f8d03aa55eb2e645a4874bdbb28adb49162e012c"
+checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
 
 [[package]]
 name = "bytecount"
@@ -1577,14 +1577,13 @@ dependencies = [
 
 [[package]]
 name = "dialoguer"
-version = "0.11.0"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "658bce805d770f407bc62102fca7c2c64ceef2fbcb2b8bd19d2765ce093980de"
+checksum = "25f104b501bf2364e78d0d3974cbc774f738f5865306ed128e1e0d7499c0ad96"
 dependencies = [
- "console 0.15.10",
+ "console 0.16.2",
  "shell-words",
  "tempfile",
- "thiserror 1.0.69",
  "zeroize",
 ]
 
@@ -1875,29 +1874,35 @@ dependencies = [
 
 [[package]]
 name = "evtx"
-version = "0.8.5"
+version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb8273ed69ad5086ec987e16e883ac35589a1cf0f2b000d965a693fc2a937a24"
+checksum = "775d27b3ad8889149c6b72e6101347a11b935b82049c40dd08fac06e777542c6"
 dependencies = [
+ "ahash",
  "anyhow",
  "bitflags 2.8.0",
+ "bumpalo",
  "byteorder",
- "chrono",
  "clap 4.5.48",
  "crc32fast",
  "dialoguer",
  "encoding",
- "hashbrown 0.14.5",
+ "glob",
+ "goblin",
  "indoc",
+ "jiff",
  "log",
- "quick-xml 0.36.2",
  "rayon",
  "serde",
  "serde_json",
  "simplelog",
  "skeptic",
- "thiserror 1.0.69",
+ "sonic-rs",
+ "tempfile",
+ "thiserror 2.0.18",
+ "utf16-simd",
  "winstructs",
+ "zmij",
 ]
 
 [[package]]
@@ -1921,6 +1926,18 @@ name = "fastrand"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+
+[[package]]
+name = "faststr"
+version = "0.2.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ca7d44d22004409a61c393afb3369c8f7bb74abcae49fe249ee01dcc3002113"
+dependencies = [
+ "bytes",
+ "rkyv",
+ "serde",
+ "simdutf8",
+]
 
 [[package]]
 name = "ff"
@@ -2113,6 +2130,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
 
 [[package]]
+name = "goblin"
+version = "0.10.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "983a6aafb3b12d4c41ea78d39e189af4298ce747353945ff5105b54a056e5cd9"
+dependencies = [
+ "log",
+ "plain",
+ "scroll 0.13.0",
+]
+
+[[package]]
 name = "group"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2178,10 +2206,6 @@ name = "hashbrown"
 version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
-dependencies = [
- "ahash",
- "allocator-api2",
-]
 
 [[package]]
 name = "hashbrown"
@@ -2703,6 +2727,47 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47f142fe24a9c9944451e8349de0a56af5f3e7226dc46f3ed4d4ecc0b85af75e"
 
 [[package]]
+name = "jiff"
+version = "0.2.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f00b5dbd620d61dfdcb6007c9c1f6054ebd75319f163d886a9055cec1155073d"
+dependencies = [
+ "jiff-static",
+ "jiff-tzdb-platform",
+ "log",
+ "portable-atomic",
+ "portable-atomic-util",
+ "serde_core",
+ "windows-sys 0.61.1",
+]
+
+[[package]]
+name = "jiff-static"
+version = "0.2.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e000de030ff8022ea1da3f466fbb0f3a809f5e51ed31f6dd931c35181ad8e6d7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "jiff-tzdb"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c900ef84826f1338a557697dc8fc601df9ca9af4ac137c7fb61d4c6f2dfd3076"
+
+[[package]]
+name = "jiff-tzdb-platform"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "875a5a69ac2bab1a891711cf5eccbec1ce0341ea805560dcd90b7a2e925132e8"
+dependencies = [
+ "jiff-tzdb",
+]
+
+[[package]]
 name = "jobserver"
 version = "0.1.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2993,6 +3058,26 @@ checksum = "635ff7aa5bb649bbcb502f80a95f48a8afcfb6908b1b8ffa94597fadf490bc49"
 dependencies = [
  "rust-toolchain",
  "version-number",
+]
+
+[[package]]
+name = "munge"
+version = "0.4.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e17401f259eba956ca16491461b6e8f72913a0a114e39736ce404410f915a0c"
+dependencies = [
+ "munge_macro",
+]
+
+[[package]]
+name = "munge_macro"
+version = "0.4.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4568f25ccbd45ab5d5603dc34318c1ec56b117531781260002151b8530a9f931"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3294,7 +3379,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "82040a392923abe6279c00ab4aff62d5250d1c8555dc780e4b02783a7aa74863"
 dependencies = [
  "fallible-iterator",
- "scroll",
+ "scroll 0.11.0",
  "uuid",
 ]
 
@@ -3400,6 +3485,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d231b230927b5e4ad203db57bbcbee2802f6bce620b1e4a9024a07d94e2907ec"
 
 [[package]]
+name = "plain"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
+
+[[package]]
 name = "plotters"
 version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3432,6 +3523,15 @@ name = "portable-atomic"
 version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f84267b20a16ea918e43c6a88433c2d54fa145c92a811b5b047ccbe153674483"
+
+[[package]]
+name = "portable-atomic-util"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a106d1259c23fac8e543272398ae0e3c0b8d33c88ed73d0cc71b0f1d902618"
+dependencies = [
+ "portable-atomic",
+]
 
 [[package]]
 name = "potential_utf"
@@ -3494,6 +3594,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8bccbff07d5ed689c4087d20d7307a52ab6141edeedf487c3876a55b86cf63df"
 
 [[package]]
+name = "ptr_meta"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b9a0cf95a1196af61d4f1cbdab967179516d9a4a4312af1f31948f8f6224a79"
+dependencies = [
+ "ptr_meta_derive",
+]
+
+[[package]]
+name = "ptr_meta_derive"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7347867d0a7e1208d93b46767be83e2b8f978c3dad35f775ac8d8847551d6fe1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "pulldown-cmark"
 version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3502,15 +3622,6 @@ dependencies = [
  "bitflags 2.8.0",
  "memchr",
  "unicase",
-]
-
-[[package]]
-name = "quick-xml"
-version = "0.36.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7649a7b4df05aed9ea7ec6f628c67c9953a43869b8bc50929569b2999d443fe"
-dependencies = [
- "memchr",
 ]
 
 [[package]]
@@ -3545,6 +3656,15 @@ name = "r-efi"
 version = "5.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "rancor"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a063ea72381527c2a0561da9c80000ef822bdd7c3241b1cc1b12100e3df081ee"
+dependencies = [
+ "ptr_meta",
+]
 
 [[package]]
 name = "rand"
@@ -3654,6 +3774,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "ref-cast"
+version = "1.0.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f354300ae66f76f1c85c5f84693f0ce81d747e2c3f21a45fef496d89c960bf7d"
+dependencies = [
+ "ref-cast-impl",
+]
+
+[[package]]
+name = "ref-cast-impl"
+version = "1.0.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7186006dcb21920990093f30e3dea63b7d6e977bf1256be20c3563a5db070da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "regex"
 version = "1.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3687,6 +3827,12 @@ name = "regex-syntax"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
+
+[[package]]
+name = "rend"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cadadef317c2f20755a64d7fdc48f9e7178ee6b0e1f7fce33fa60f1d68a276e6"
 
 [[package]]
 name = "reqwest"
@@ -3763,6 +3909,35 @@ dependencies = [
  "libc",
  "untrusted",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "rkyv"
+version = "0.8.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73389e0c99e664f919275ab5b5b0471391fe9a8de61e1dff9b1eaf56a90f16e3"
+dependencies = [
+ "bytes",
+ "hashbrown 0.17.0",
+ "indexmap 2.14.0",
+ "munge",
+ "ptr_meta",
+ "rancor",
+ "rend",
+ "rkyv_derive",
+ "tinyvec",
+ "uuid",
+]
+
+[[package]]
+name = "rkyv_derive"
+version = "0.8.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d2ed0b54125315fb36bd021e82d314d1c126548f871634b483f46b31d13cac6"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4026,6 +4201,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04c565b551bafbef4157586fa379538366e4385d42082f255bfd96e4fe8519da"
 
 [[package]]
+name = "scroll"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1257cd4248b4132760d6524d6dda4e053bc648c9070b960929bf50cfb1e7add"
+dependencies = [
+ "scroll_derive",
+]
+
+[[package]]
+name = "scroll_derive"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed76efe62313ab6610570951494bdaa81568026e0318eaa55f167de70eeea67d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "sct"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4245,6 +4440,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d66dc143e6b11c1eddc06d5c423cfc97062865baf299914ab64caa38182078fe"
 
 [[package]]
+name = "simdutf8"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
+
+[[package]]
 name = "simplelog"
 version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4309,6 +4510,45 @@ checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
  "windows-sys 0.61.1",
+]
+
+[[package]]
+name = "sonic-number"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3775c3390edf958191f1ab1e8c5c188907feebd0f3ce1604cb621f72961dbf32"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
+name = "sonic-rs"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d971cc77a245ccf1756dbd1a87c3e7f709c0191464096510d43eec056d0f2c4f"
+dependencies = [
+ "ahash",
+ "bumpalo",
+ "bytes",
+ "cfg-if",
+ "faststr",
+ "itoa",
+ "ref-cast",
+ "serde",
+ "simdutf8",
+ "sonic-number",
+ "sonic-simd",
+ "thiserror 2.0.18",
+ "zmij",
+]
+
+[[package]]
+name = "sonic-simd"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f99e664ecd2d85a68c87e3c7a3cfe691f647ea9e835de984aba4d54a41f817d4"
+dependencies = [
+ "cfg-if",
 ]
 
 [[package]]
@@ -4849,6 +5089,15 @@ name = "tinyvec"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "87cc5ceb3875bb20c2890005a4e226a4651264a5c75edb2421b52861a0a0cb50"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
@@ -5170,6 +5419,15 @@ name = "urlencoding"
 version = "2.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
+
+[[package]]
+name = "utf16-simd"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e58ccaaacb51ac3f769e61e1494a3856a0ef2e6749e19f5367a9e846f8c21168"
+dependencies = [
+ "sonic-rs",
+]
 
 [[package]]
 name = "utf8-ranges"
@@ -6002,3 +6260,9 @@ dependencies = [
  "quote",
  "syn 2.0.117",
 ]
+
+[[package]]
+name = "zmij"
+version = "1.0.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -71,7 +71,7 @@ ere_automator_procmacro = { version = "=0.0.9950", path = "subprojects/ere/ere_a
 ere_datetimes_impl = { version = "=0.0.9960", path = "subprojects/ere/ere_datetimes_impl", package = "super-speedy-syslog-searcher_ere_datetimes_impl" }
 # TODO: [2025/12] update `evtx` and use `RecordId` when Issue 234 is merged and released
 #       https://github.com/omerbenamram/evtx/issues/234
-evtx = { version = "=0.8.5", features = ["multithreading"] }
+evtx = { version = "=0.11.2", features = ["multithreading"] }
 flate2 = "=1.1.9"
 include_dir = "=0.7.4"
 itertools = "=0.14.0"

--- a/src/data/evtx.rs
+++ b/src/data/evtx.rs
@@ -10,8 +10,11 @@ use std::io::{
     ErrorKind,
 };
 
-pub(crate) use ::evtx::err::EvtxError;
-pub(crate) use ::evtx::SerializedEvtxRecord;
+pub(crate) use ::evtx::{
+    err::EvtxError,
+    SerializedEvtxRecord,
+    Timestamp,
+};
 #[allow(unused_imports)]
 use ::more_asserts::{
     assert_ge,
@@ -37,13 +40,23 @@ use ::si_trace_print::{
 
 #[doc(hidden)]
 use crate::common::{
+    debug_panic,
     NLc,
     NLs,
 };
+use crate::de_err;
 use crate::data::common::DtBegEndPairOpt;
-use crate::data::datetime::DateTimeL;
+use crate::data::datetime::{
+    DateTime,
+    DateTimeL,
+    DateTimeLOpt,
+    FixedOffset,
+    Utc,
+};
 #[cfg(any(debug_assertions, test))]
 use crate::debug::printers::buffer_to_String_noraw;
+
+pub type TimestampOpt = Option<Timestamp>;
 
 /// From private `evtx::evtx_record::RecordId`.
 ///
@@ -61,6 +74,52 @@ pub type ResultEvtxRS = std::result::Result<EvtxRS, EvtxError>;
 
 const TIMECREATED_BEG_SUBSTR: &str = "<TimeCreated SystemTime=\"";
 const TIMECREATED_END_SUBCHAR: char = '\"';
+
+/// Convert a `evtx` "timestamp" (`jiff::Timestamp`)
+/// to a `s4` "datetime" (`chrono::DateTime<Local>`).
+pub fn timestamp_to_datetimelopt(
+    timestamp: &Timestamp,
+    fixed_offset: &FixedOffset,
+) -> DateTimeLOpt {
+    let ns128: i128 = timestamp.as_nanosecond();
+    let ns64: i64 = match i64::try_from(ns128) {
+        Ok(ns) => ns,
+        Err(err) => {
+            debug_panic!("timestamp.as_nanosecond() value {:?} does not fit in i64: {}", ns128, err);
+            return DateTimeLOpt::None;
+        }
+    };
+    let dt_utc = DateTime::<Utc>::from_timestamp_nanos(ns64);
+    let dt_fo = dt_utc.with_timezone(fixed_offset);
+
+    DateTimeLOpt::Some(dt_fo)
+}
+
+/// Convert a `s4` "datetime" (`DateTimeL`)
+/// to a `evtx` "timestamp" (`jiff::Timestamp`).
+pub fn datetimelopt_to_timestampopt(
+    datetimeopt: &DateTimeLOpt,
+) -> TimestampOpt {
+    let dt: &DateTimeL = match datetimeopt {
+        DateTimeLOpt::None => return TimestampOpt::None,
+        DateTimeLOpt::Some(dt) => dt,
+    };
+    let ns: i64 = match dt.timestamp_nanos_opt() {
+        Some(ns) => ns,
+        None => {
+            de_err!("datetime.timestamp_nanos_opt() returned None for datetime {:?}", dt);
+            return TimestampOpt::None;
+        }
+    };
+
+    match Timestamp::from_nanosecond(ns as i128) {
+        Ok(ts) => TimestampOpt::Some(ts),
+        Err(err) => {
+            de_err!("Timestamp::from_nanosecond({:?}) returned Err {}", ns, err);
+            TimestampOpt::None
+        }
+    }
+}
 
 /// A `Evtx` holds information taken from an [`EvtxRecord`], a
 /// [Windows Event Log] record.
@@ -130,10 +189,16 @@ impl Evtx {
     /// Create a new `Evtx`.
     pub fn from_resultserializedrecord(
         record: &ResultEvtxRS,
+        fixed_offset: &FixedOffset,
     ) -> Result<Evtx, Error> {
         match record {
             Ok(record) => {
-                Result::Ok(Self::from_evtxrs(record))
+                Result::Ok(
+                    Self::from_evtxrs(
+                        record,
+                        fixed_offset,
+                    )
+                )
             }
             Err (err) => {
                 Err(
@@ -149,9 +214,20 @@ impl Evtx {
     /// Create a new `Evtx`.
     pub fn from_evtxrs(
         record: &EvtxRS,
+        fixed_offset: &FixedOffset,
     ) -> Evtx {
         let id: RecordId = record.event_record_id;
-        let dt: DateTimeL = record.timestamp.into();
+        let dt: DateTimeL = match timestamp_to_datetimelopt(
+            &record.timestamp,
+            fixed_offset,
+        ) {
+            DateTimeLOpt::None => {
+                debug_panic!("timestamp_to_datetimelopt returned None for timestamp {:?}", record.timestamp);
+
+                DateTime::<Utc>::from_timestamp_nanos(0).with_timezone(fixed_offset)
+            }
+            DateTimeLOpt::Some(dt) => dt,
+        };
         // add a newline to the `data` so it easily prints in a line-oriented
         // fashion
         let data: String = record.data.clone() + NLs;

--- a/src/readers/evtxreader.rs
+++ b/src/readers/evtxreader.rs
@@ -26,10 +26,6 @@ use std::io::{
 };
 use std::path::Path;
 
-use ::chrono::{
-    DateTime,
-    Utc,
-};
 use ::evtx::{
     EvtxParser,
     ParserSettings,
@@ -63,6 +59,7 @@ use ::si_trace_print::{
 use ::tempfile::NamedTempFile;
 
 use crate::common::{
+    debug_panic,
     Count,
     FPath,
     File,
@@ -79,7 +76,13 @@ use crate::data::datetime::{
     Result_Filter_DateTime2,
     SystemTime,
 };
-use crate::data::evtx::Evtx;
+use crate::data::evtx::{
+    Evtx,
+    Timestamp,
+    TimestampOpt,
+    timestamp_to_datetimelopt,
+    datetimelopt_to_timestampopt,
+};
 use crate::de_err;
 use crate::readers::filedecompressor::decompress_to_ntf;
 use crate::readers::helpers::path_to_fpath;
@@ -88,49 +91,9 @@ use crate::readers::summary::Summary;
 // ----------
 // EvtxReader
 
-/// The `DateTime` used by [`EvtxParser`], field [`EvtxRecord.timestamp`] which
-/// is referred to as a "timestamp".
-///
-/// [`EvtxParser`]: https://docs.rs/evtx/0.8.1/evtx/struct.EvtxParser.html
-/// [`EvtxRecord.timestamp`]: https://docs.rs/evtx/0.8.1/evtx/struct.EvtxRecord.html#structfield.timestamp
-pub type Timestamp = DateTime<Utc>;
-/// Optional [`Timestamp`].
-pub type TimestampOpt = Option<Timestamp>;
-
 // TODO: change to a typed `struct EventsKey(...)`
-pub type EventsKey = (Timestamp, usize);
+pub type EventsKey = (DateTimeL, usize);
 pub type Events = BTreeMap<EventsKey, Evtx>;
-
-/// Convert a `evtx` "timestamp" (`DateTime<Utc>`)
-/// to a `s4` "datetime" (`DateTimeL`).
-pub fn timestamp_to_datetimel(
-    timestamp: &Timestamp,
-) -> DateTimeL {
-    timestamp.with_timezone(
-        &FixedOffset::east_opt(0).unwrap()
-    )
-}
-
-/// Convert a `s4` "datetime" (`DateTimeL`)
-/// to a `evtx` "timestamp" (`DateTime<Utc>`).
-pub fn datetimel_to_timestamp(
-    datetime: &DateTimeL,
-) -> Timestamp {
-    datetime.with_timezone(&Utc)
-}
-
-/// Convert a `s4` "datetime" (`DateTimeL`)
-/// to a `evtx` "timestamp" (`DateTime<Utc>`).
-pub fn datetimelopt_to_timestampopt(
-    datetimeopt: &DateTimeLOpt,
-) -> TimestampOpt {
-    match datetimeopt {
-        Some(dt) => {
-            Some(datetimel_to_timestamp(dt))
-        }
-        None => None,
-    }
-}
 
 /// A version of [`dt_pass_filters`] that takes a `Timestamp` instead of a
 /// [`DateTimeL`].
@@ -224,6 +187,8 @@ pub struct EvtxReader {
     ///
     /// [`FPath`]: crate::common::FPath
     path: FPath,
+    /// The `FixedOffset` to use for converting `Timestamp`s to `DateTimeL`s.
+    fixed_offset: FixedOffset,
     /// If necessary, the extracted evtx file as a temporary file.
     named_temp_file: Option<NamedTempFile>,
     /// Summary statistic.
@@ -312,6 +277,7 @@ impl EvtxReader {
     pub fn new(
         path: FPath,
         filetype: FileType,
+        fixed_offset: FixedOffset,
     ) -> Result<EvtxReader> {
         def1n!("({:?}, {:?})", path, filetype);
 
@@ -391,6 +357,7 @@ impl EvtxReader {
             evtxparser,
             events: Events::new(),
             path,
+            fixed_offset,
             named_temp_file,
             events_processed: 0,
             events_accepted: 0,
@@ -422,8 +389,8 @@ impl EvtxReader {
         dt_filter_before: &DateTimeLOpt,
     ) {
         defn!("({:?}, {:?})", dt_filter_after, dt_filter_before);
-        let ts_filter_after = datetimelopt_to_timestampopt(dt_filter_after);
-        let ts_filter_before = datetimelopt_to_timestampopt(dt_filter_before);
+        let ts_filter_after: TimestampOpt = datetimelopt_to_timestampopt(dt_filter_after);
+        let ts_filter_before: TimestampOpt = datetimelopt_to_timestampopt(dt_filter_before);
         let mut timestamp_last: TimestampOpt = TimestampOpt::None;
         for (index, result) in self
             .evtxparser
@@ -439,33 +406,33 @@ impl EvtxReader {
                         match self.ts_first_processed.as_ref()
                         {
                             Some(ts_first_) => {
-                                if ts_first_ > &record.timestamp {
-                                    self.ts_first_processed = Some(record.timestamp);
+                                if ts_first_ > &record.timestamp.into() {
+                                    self.ts_first_processed = Some(record.timestamp.into());
                                 }
                             }
-                            None => self.ts_first_processed = Some(record.timestamp),
+                            None => self.ts_first_processed = Some(record.timestamp.into()),
                         }
                     );
                     summary_stat!(
                         match self.ts_last_processed.as_ref()
                         {
                             Some(ts_last_) => {
-                                if ts_last_ < &record.timestamp {
-                                    self.ts_last_processed = Some(record.timestamp);
+                                if ts_last_ < &record.timestamp.into() {
+                                    self.ts_last_processed = Some(record.timestamp.into());
                                 }
                             }
-                            None => self.ts_last_processed = Some(record.timestamp),
+                            None => self.ts_last_processed = Some(record.timestamp.into()),
                         }
                     );
                     // update "out of order" counter
                     if let Some(ts_last_) = timestamp_last.as_ref() {
                         summary_stat!(
-                            if ts_last_ > &record.timestamp {
+                            if ts_last_ > &record.timestamp.into() {
                                 self.out_of_order += 1;
                             }
                         );
                     }
-                    timestamp_last = Some(record.timestamp);
+                    timestamp_last = Some(record.timestamp.into());
 
                     // filter by date
                     match ts_pass_filters(&record.timestamp, &ts_filter_after, &ts_filter_before) {
@@ -482,10 +449,21 @@ impl EvtxReader {
                         }
                     }
 
-                    let timestamp = record.timestamp;
-                    let evtx = Evtx::from_evtxrs(&record);
-                    self.events
-                        .insert((timestamp, index), evtx);
+                    let datetime_opt: DateTimeLOpt = timestamp_to_datetimelopt(
+                        &record.timestamp, &self.fixed_offset
+                    );
+                    let datetime_: DateTimeL = match datetime_opt {
+                        DateTimeLOpt::None => {
+                            de_err!("timestamp_to_datetimelopt() returned None for timestamp {:?}", record.timestamp);
+                            continue;
+                        }
+                        DateTimeLOpt::Some(dt) => dt,
+                    };
+                    let evtx: Evtx = Evtx::from_evtxrs(&record, &self.fixed_offset);
+                    let key: EventsKey = (datetime_, index);
+                    if let Some(e) = self.events.insert(key, evtx) {
+                        debug_panic!("Duplicate key {:?} found in events BTreeMap, this should not happen: {:?}", key, e);
+                    }
 
                     summary_stat!(self.events_accepted += 1);
 
@@ -493,19 +471,19 @@ impl EvtxReader {
                         match self.ts_first_accepted.as_ref()
                         {
                             Some(ts_first_) => {
-                                if ts_first_ > &timestamp {
-                                    self.ts_first_accepted = Some(timestamp);
+                                if ts_first_ > &record.timestamp {
+                                    self.ts_first_accepted = Some(record.timestamp);
                                 }
                             }
-                            None => self.ts_first_accepted = Some(timestamp),
+                            None => self.ts_first_accepted = Some(record.timestamp),
                         }
                         match self.ts_last_accepted.as_ref() {
                             Some(ts_last_) => {
-                                if ts_last_ < &timestamp {
-                                    self.ts_last_accepted = Some(timestamp);
+                                if ts_last_ < &record.timestamp {
+                                    self.ts_last_accepted = Some(record.timestamp);
                                 }
                             }
-                            None => self.ts_last_accepted = Some(timestamp),
+                            None => self.ts_last_accepted = Some(record.timestamp),
                         }
                     );
                 }
@@ -547,7 +525,8 @@ impl EvtxReader {
     pub fn dt_first_processed(&self) -> DateTimeLOpt {
         match self.ts_first_processed {
             TimestampOpt::None => DateTimeLOpt::None,
-            TimestampOpt::Some(ts) => DateTimeLOpt::Some(timestamp_to_datetimel(&ts)),
+            TimestampOpt::Some(ts) =>
+                timestamp_to_datetimelopt(&ts, &self.fixed_offset),
         }
     }
 
@@ -555,7 +534,8 @@ impl EvtxReader {
     pub fn dt_last_processed(&self) -> DateTimeLOpt {
         match self.ts_last_processed {
             TimestampOpt::None => DateTimeLOpt::None,
-            TimestampOpt::Some(ts) => DateTimeLOpt::Some(timestamp_to_datetimel(&ts)),
+            TimestampOpt::Some(ts) =>
+                timestamp_to_datetimelopt(&ts, &self.fixed_offset),
         }
     }
 
@@ -564,7 +544,8 @@ impl EvtxReader {
     pub fn dt_first_accepted(&self) -> DateTimeLOpt {
         match self.ts_first_accepted {
             TimestampOpt::None => DateTimeLOpt::None,
-            TimestampOpt::Some(ts) => DateTimeLOpt::Some(timestamp_to_datetimel(&ts)),
+            TimestampOpt::Some(ts) =>
+                timestamp_to_datetimelopt(&ts, &self.fixed_offset),
         }
     }
 
@@ -573,7 +554,8 @@ impl EvtxReader {
     pub fn dt_last_accepted(&self) -> DateTimeLOpt {
         match self.ts_last_accepted {
             TimestampOpt::None => DateTimeLOpt::None,
-            TimestampOpt::Some(ts) => DateTimeLOpt::Some(timestamp_to_datetimel(&ts)),
+            TimestampOpt::Some(ts) =>
+                timestamp_to_datetimelopt(&ts, &self.fixed_offset),
         }
     }
 

--- a/src/s4/s4.rs
+++ b/src/s4/s4.rs
@@ -4448,6 +4448,7 @@ fn exec_evtxprocessor(
     let mut evtxreader: EvtxReader = match EvtxReader::new(
         path.clone(),
         filetype,
+        tz_offset,
     ) {
         Ok(val) => val,
         Err(err) => {
@@ -5402,6 +5403,7 @@ fn processing_loop(
 
     // track which paths had syslines
     let mut paths_printed_logmessages: SetPathId = SetPathId::with_capacity(file_count);
+    let mut _messages_printed: usize = 0;
 
     //
     // the main processing loop (e.g. the "game loop")
@@ -5861,6 +5863,7 @@ fn processing_loop(
                             summaryprinted.flushed += 1;
                         }
                     }
+                    _messages_printed += 1;
                     if cli_opt_summary {
                         paths_printed_logmessages.insert(*pathid);
                         // update the per processing file `SummaryPrinted`
@@ -5905,6 +5908,7 @@ fn processing_loop(
                             summaryprinted.flushed += 1;
                         }
                     }
+                    _messages_printed += 1;
                     if cli_opt_summary {
                         paths_printed_logmessages.insert(*pathid);
                         // update the per processing file `SummaryPrinted`
@@ -5946,6 +5950,7 @@ fn processing_loop(
                             summaryprinted.flushed += 1;
                         }
                     }
+                    _messages_printed += 1;
                     if cli_opt_summary {
                         paths_printed_logmessages.insert(*pathid);
                         // update the per processing file `SummaryPrinted`
@@ -5987,6 +5992,7 @@ fn processing_loop(
                             summaryprinted.flushed += 1;
                         }
                     }
+                    _messages_printed += 1;
                     if cli_opt_summary {
                         paths_printed_logmessages.insert(*pathid);
                         // update the per processing file `SummaryPrinted`
@@ -6047,6 +6053,7 @@ fn processing_loop(
                             summaryprinted.flushed += 1;
                         }
                     }
+                    _messages_printed += 1;
                     if cli_opt_summary {
                         paths_printed_logmessages.insert(*pathid);
                         // update the per processing file `SummaryPrinted`

--- a/src/tests/common.rs
+++ b/src/tests/common.rs
@@ -4245,12 +4245,15 @@ lazy_static! {
     pub static ref EVTX_KPNP_FPATH: FPath = FPath::from(EVTX_KPNP_STR_PATH_PROJD);
     pub static ref EVTX_KPNP_F: File =
         File::open(fpath_to_path(&EVTX_KPNP_FPATH)).unwrap();
+
+    pub static ref EVTX_KPNP_ENTRY_FO: FixedOffset = FO_0;
+
     /// Entry 1 datetime
     pub static ref EVTX_KPNP_ENTRY1_DT: DateTimeL =
-        ymdhmsm(&FO_0, 2023, 3, 10, 3, 49, 43, 558721);
+        ymdhmsm(&EVTX_KPNP_ENTRY_FO, 2023, 3, 10, 3, 49, 43, 558721);
     /// Entry last datetime
     pub static ref EVTX_KPNP_ENTRY227_DT: DateTimeL =
-        ymdhmsm(&FO_0, 2023, 3, 17, 21, 21, 46, 786681);
+        ymdhmsn(&EVTX_KPNP_ENTRY_FO, 2023, 3, 17, 21, 21, 46, 786681900);
 
     // EVTX_KPNP bz2
 

--- a/src/tests/evtxreader_tests.rs
+++ b/src/tests/evtxreader_tests.rs
@@ -42,6 +42,7 @@ use crate::tests::common::{
     EVTX_KPNP_ENTRY227_DT,
     EVTX_KPNP_EVENT_COUNT,
     EVTX_KPNP_FPATH,
+    EVTX_KPNP_ENTRY_FO,
     EVTX_KPNP_GZ_ENTRY1_DT,
     EVTX_KPNP_GZ_ENTRY227_DT,
     EVTX_KPNP_GZ_EVENT_COUNT,
@@ -60,6 +61,7 @@ use crate::tests::common::{
     EVTX_KPNP_XZ_FPATH,
     EVTX_NE_FPATH,
     NTF_LOG_EMPTY_FPATH,
+    FO_E8,
 };
 
 /// Error, broken data
@@ -104,7 +106,7 @@ fn test_EvtxReader_new(
     path: &FPath,
     ok: bool,
 ) {
-    match EvtxReader::new(path.clone(), FT_NORM) {
+    match EvtxReader::new(path.clone(), FT_NORM, FO_E8) {
         Ok(_) => {
             assert!(ok, "EvtxReader::new({:?}) should have failed", path);
         }
@@ -120,7 +122,7 @@ fn test_new_EvtxReader_no_file_permissions() {
     let ntf = create_temp_file_no_permissions(".evtx");
     let path = ntf.path();
     let fpath = path_to_fpath(path);
-    match EvtxReader::new(fpath.clone(), FT_NORM) {
+    match EvtxReader::new(fpath.clone(), FT_NORM, FO_E8) {
         Ok(_) => {
             panic!("no permissions to read {:?}", path);
         }
@@ -134,7 +136,7 @@ fn test_new_EvtxReader_no_file_permissions() {
 #[test_case(&EVTX_NE_FPATH)]
 #[test_case(&EVTX_KPNP_FPATH)]
 fn test_mtime(path: &FPath) {
-    let er1 = EvtxReader::new(path.clone(), FT_NORM).unwrap();
+    let er1 = EvtxReader::new(path.clone(), FT_NORM, FO_E8).unwrap();
     // merely run the function
     _ = er1.mtime();
 }
@@ -144,7 +146,7 @@ fn test_mtime(path: &FPath) {
 #[test_case(&EVTX_NE_FPATH)]
 #[test_case(&EVTX_KPNP_FPATH)]
 fn test_EvtxReader_summary_empty(path: &FPath) {
-    let evtxreader = EvtxReader::new(path.clone(), FT_NORM).unwrap();
+    let evtxreader = EvtxReader::new(path.clone(), FT_NORM, FO_E8).unwrap();
     _ = evtxreader.summary();
     _ = evtxreader.summary_complete();
 }
@@ -246,7 +248,6 @@ fn test_EvtxReader_next_summary(
     match filetype {
         FileType::Evtx { archival_type } => {
             match archival_type {
-                // XXX: forces error if new FileTypeArchive is added
                 FileTypeArchive::Normal
                 | FileTypeArchive::Bz2
                 | FileTypeArchive::Gz
@@ -264,6 +265,7 @@ fn test_EvtxReader_next_summary(
     let mut evtxreader = EvtxReader::new(
         path.clone(),
         filetype,
+        *EVTX_KPNP_ENTRY_FO,
     ).unwrap();
     evtxreader.analyze(&None, &None);
     while let Some(evtx_) = evtxreader.next() {
@@ -285,13 +287,25 @@ fn test_EvtxReader_next_summary(
     assert_eq!(summary.evtxreader_out_of_order, out_of_order,
         "summary.out_of_order");
     assert_eq!(summary.evtxreader_datetime_first_accepted, datetime_first_accepted,
-        "summary.datetime_first_accepted");
+        "summary.datetime_first_accepted\nexpect {}\nactual {}\n",
+        datetime_first_accepted.unwrap_or_default(),
+        summary.evtxreader_datetime_first_accepted.unwrap_or_default(),
+    );
     assert_eq!(summary.evtxreader_datetime_last_accepted, datetime_last_accepted,
-        "summary.datetime_last_accepted");
+        "summary.datetime_last_accepted\nexpect {}\nactual {}\n",
+        datetime_last_accepted.unwrap_or_default(),
+        summary.evtxreader_datetime_last_accepted.unwrap_or_default(),
+    );
     assert_eq!(summary.evtxreader_datetime_first_processed, datetime_first_processed,
-        "summary.datetime_first_processed");
+        "summary.datetime_first_processed\nexpect {}\nactual {}\n",
+        datetime_first_processed.unwrap_or_default(),
+        summary.evtxreader_datetime_first_processed.unwrap_or_default(),
+    );
     assert_eq!(summary.evtxreader_datetime_last_processed, datetime_last_processed,
-        "summary.datetime_last_processed");
+        "summary.datetime_last_processed\nexpect {}\nactual {}\n",
+        datetime_last_processed.unwrap_or_default(),
+        summary.evtxreader_datetime_last_processed.unwrap_or_default(),
+    );
 
     // assert Summary
     let summary_c = evtxreader.summary_complete();

--- a/src/tests/printers_tests.rs
+++ b/src/tests/printers_tests.rs
@@ -333,15 +333,15 @@ fn test_PrinterLogMessage_print_fixedstruct(
     );
 }
 
-#[test_case(CCA, CLR, None, None, None, 321782, 1589; "a")]
-#[test_case(CCU, CLR, None, None, None, 321782, 1589; "b")]
-#[test_case(CCN, CLR, None, None, None, 321782, 227; "c")]
-#[test_case(CCA, CLR, Some(FILEU), None, None, 388782, 34409; "d")]
-#[test_case(CCU, CLR, None, Some(DATE), None, 447407, 34409; "e")]
-#[test_case(CCN, CLR, None, None, Some(FO_P8), 321782, 227; "f")]
-#[test_case(CCA, CLR, Some(FILEU), Some(DATE), None, 514407, 34409; "g")]
-#[test_case(CCU, CLR, Some(FILEU), Some(DATE), Some(FO_P8), 514407, 34409; "h")]
-#[test_case(CCN, CLR, None, Some(DATE), Some(FO_P8), 447407, 339; "i")]
+#[test_case(CCA, CLR, None, None, None, 322009, 1589; "a")]
+#[test_case(CCU, CLR, None, None, None, 322009, 1589; "b")]
+#[test_case(CCN, CLR, None, None, None, 322009, 227; "c")]
+#[test_case(CCA, CLR, Some(FILEU), None, None, 390825, 35317; "d")]
+#[test_case(CCU, CLR, None, Some(DATE), None, 451039, 35317; "e")]
+#[test_case(CCN, CLR, None, None, Some(FO_P8), 322009, 227; "f")]
+#[test_case(CCA, CLR, Some(FILEU), Some(DATE), None, 519855, 35317; "g")]
+#[test_case(CCU, CLR, Some(FILEU), Some(DATE), Some(FO_P8), 519855, 35317; "h")]
+#[test_case(CCN, CLR, None, Some(DATE), Some(FO_P8), 451039, 340; "i")]
 fn test_PrinterLogMessage_print_evtx(
     colorchoice: ColorChoice,
     color: Color,
@@ -363,6 +363,7 @@ fn test_PrinterLogMessage_print_evtx(
     let mut er = EvtxReader::new(
         EVTX_KPNP_FPATH.clone(),
         FT_EVTX_NORM,
+        FO_P8,
     ).unwrap();
     let mut prints: usize = 0;
     let mut printed_bytes: usize = 0;


### PR DESCRIPTION
Bump to `evtx` version `0.11.`.

Update `Timestamp` type to different type used by `evtx`.